### PR TITLE
Change child container ref on parent change

### DIFF
--- a/packages/brandi-react/src/container/ContainerProvider.tsx
+++ b/packages/brandi-react/src/container/ContainerProvider.tsx
@@ -10,9 +10,15 @@ export const ContainerProvider: React.FunctionComponent<{
   isolated?: boolean;
 }> = ({ children, container, isolated = false }) => {
   const parentContainer = useContainer(false);
-  const clonedContainer = React.useMemo(() => container.clone(), [container]);
 
-  if (!isolated) clonedContainer.extend(parentContainer);
+  const extend = !isolated ? parentContainer : null;
+
+  const clonedContainer = React.useMemo(() => {
+    const cloned = container.clone()
+    if (extend) cloned.extend(extend)
+    return cloned
+  }, [container, extend]);
+
 
   return (
     <ContainerContext.Provider value={clonedContainer}>


### PR DESCRIPTION
I don't really know how to save sate with testing-library between two renders. If you need test cases for this exact behavior let me know.

But I guess this is major api change.