### PR TITLE
Add types path to package exports

### DIFF
--- a/packages/brandi-react/package.json
+++ b/packages/brandi-react/package.json
@@ -10,7 +10,8 @@
   "exports": {
     "import": "./lib/brandi-react.mjs",
     "require": "./lib/brandi-react.js",
-    "default": "./lib/brandi-react.js"
+    "default": "./lib/brandi-react.js",
+    "types": "./lib/typings/index.d.ts"
   },
   "typings": "./lib/typings/index.d.ts",
   "sideEffects": false,

--- a/packages/brandi/package.json
+++ b/packages/brandi/package.json
@@ -10,7 +10,8 @@
   "exports": {
     "import": "./lib/brandi.mjs",
     "require": "./lib/brandi.js",
-    "default": "./lib/brandi.js"
+    "default": "./lib/brandi.js",
+    "types": "./lib/typings/index.d.ts"
   },
   "typings": "./lib/typings/index.d.ts",
   "files": [


### PR DESCRIPTION
This is due to TS ignoring the `typings` top level key when consuming projects use `"moduleResolution": "NodeNext"` to import from a package with an `"exports": {...}` entry.

This is unfortunately a fairly high priority merge for us as it is a blocking issue.  Tested locally inside of my nodeModules.  As an aside, it also works if you delete the `exports` key, but I believe this is a good thing to have as it is more nuanced and future proof.